### PR TITLE
Add personal settings

### DIFF
--- a/modules/@apostrophecms/settings/index.js
+++ b/modules/@apostrophecms/settings/index.js
@@ -1,0 +1,21 @@
+module.exports = {
+  options: {
+    subforms: {
+      title: {
+        fields: [ 'title' ],
+        protection: true,
+        reload: true
+      },
+      changePassword: {
+        fields: [ 'password' ]
+      }
+    },
+
+    groups: {
+      account: {
+        label: 'Account',
+        subforms: [ 'title', 'changePassword' ]
+      }
+    }
+  }
+};


### PR DESCRIPTION
  https://linear.app/apostrophecms/issue/PRO-4644/the-public-demo-should-show-off-personal-settings-so-people-can

  Add the same config we're using in testbed to starter kits.

  Implement it for the user's full name, password.